### PR TITLE
🛡️ Sentinel: [HIGH] Harden RSA key size to 2048 bits

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "ansi-regex": "^5.0.1",
     "express": "^4.20.0",
-    "node-fetch": "^2.7.3",
+    "node-fetch": "^2.7.0",
     "node-rsa": "^2.0.0",
     "playwright": "^1.61.1"
   },

--- a/src/encryption.js
+++ b/src/encryption.js
@@ -1,7 +1,12 @@
 const NodeRSA = require('node-rsa');
 const RSA = NodeRSA.NodeRSA || NodeRSA;
 
-const key = new RSA({ b: 512 }); // Small key for demo purposes
+/**
+ * 🛡️ Sentinel Security Enhancement:
+ * Increased RSA key size to 2048 bits to meet modern security standards (NIST).
+ * 512-bit keys are considered insecure and susceptible to factoring attacks.
+ */
+const key = new RSA({ b: 2048 });
 
 function generateKeys() {
     return {


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The application was using a 512-bit RSA key for encryption/decryption. 512-bit RSA keys are cryptographically weak and can be factored in a short amount of time using modern computing power.
🎯 Impact: Sensitive data encrypted with a 512-bit key could be decrypted by an attacker, leading to data exposure.
🔧 Fix: Increased the RSA key size to 2048 bits in `src/encryption.js` to comply with NIST security standards.
✅ Verification: Ran `yarn mocha test/encryption.test.js` to ensure encryption and decryption still work correctly.

Also corrected an invalid `node-fetch` version in `package.json` (^2.7.3 -> ^2.7.0) that was preventing successful dependency installation and environment setup.

---
*PR created automatically by Jules for task [8754068566778646862](https://jules.google.com/task/8754068566778646862) started by @VersoriumX*