### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix sensitive data leakage in logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** Inherited properties like `constructor` and `toString` were accessible via the `/api/token` endpoint, and sensitive keys like `__proto__` could be added to the tokens object.
 **Learning:** Standard JavaScript objects inherit from `Object.prototype`, making them susceptible to prototype-related attacks if user-supplied keys are not properly validated.
 **Prevention:** Use `Object.create(null)` for data-storage objects to prevent property inheritance, and explicitly block sensitive keys like `__proto__`, `constructor`, and `prototype`.
+
+## 2025-05-15 - Sensitive Data Leakage in Logs
+**Vulnerability:** Sensitive API keys (`access_key`, `CMC_PRO_API_KEY`) were being logged to the console in plain text when external API requests failed.
+**Learning:** Logging the full URL of failed requests is common for debugging but dangerous when credentials are passed as query parameters.
+**Prevention:** Implement redaction for sensitive query parameters in centralized logging or fetch wrappers before outputting to logs.

--- a/src/api.js
+++ b/src/api.js
@@ -21,7 +21,9 @@ async function fetchWithCache(url, cache, headers = {}) {
         cache.timestamp = now;
         return data;
     } catch (error) {
-        console.error(`Error fetching from ${url}:`, error);
+        // 🛡️ Sentinel: Redact sensitive API keys from URL before logging to prevent data leakage.
+        const redactedUrl = url.replace(/(access_key|CMC_PRO_API_KEY)=[^&]+/g, '$1=[REDACTED]');
+        console.error(`Error fetching from ${redactedUrl}:`, error);
         if (cache.data) return cache.data; // Return stale data on error
         throw error;
     }


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Sensitive API keys (`access_key` and `CMC_PRO_API_KEY`) were being logged to the console in plain text whenever an external API request failed.
🎯 **Impact:** Exposure of these keys in logs could lead to unauthorized use of the Metals-API and CoinMarketCap API services, potentially leading to exhausted quotas or data misuse.
🔧 **Fix:** Implemented a regex-based redaction in `src/api.js` that replaces the values of `access_key` and `CMC_PRO_API_KEY` with `[REDACTED]` before the URL is logged to the console.
✅ **Verification:**
- Created a reproduction script that used fake keys and triggered 401 errors.
- Verified that the logs now show `[REDACTED]` instead of the fake keys.
- Ran the existing test suite (`yarn test`) and verified that all 9 tests passed.
- Updated the security journal in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [8193810482910348198](https://jules.google.com/task/8193810482910348198) started by @VersoriumX*