### PR TITLE
🛡️ Sentinel: [HIGH] Redact sensitive API keys from error logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -4,3 +4,8 @@
 **Vulnerability:** Inherited properties like `constructor` and `toString` were accessible via the `/api/token` endpoint, and sensitive keys like `__proto__` could be added to the tokens object.
 **Learning:** Standard JavaScript objects inherit from `Object.prototype`, making them susceptible to prototype-related attacks if user-supplied keys are not properly validated.
 **Prevention:** Use `Object.create(null)` for data-storage objects to prevent property inheritance, and explicitly block sensitive keys like `__proto__`, `constructor`, and `prototype`.
+
+## 2025-05-15 - Sensitive Data Leakage in Error Logs
+**Vulnerability:** External API keys were leaked in application logs when `fetch` requests failed, as the full URL (including query parameters) was logged.
+**Learning:** Logging entire URLs or raw error objects can inadvertently expose credentials. Even if the log message is sanitized, the error object itself might contain the original request details.
+**Prevention:** Explicitly redact sensitive query parameters from URLs before logging and avoid logging raw error objects; log only `error.message` or carefully whitelist properties.

--- a/src/api.js
+++ b/src/api.js
@@ -34,7 +34,13 @@ async function fetchWithCache(url, cache, headers = {}) {
             cache.timestamp = now;
             return data;
         } catch (error) {
-            console.error(`Error fetching from ${url}:`, error);
+            /**
+             * 🛡️ Sentinel Security Enhancement:
+             * Redact sensitive query parameters from URLs in error logs to prevent credential leakage.
+             * We log only the error message to avoid potential secret leakage via the full error object properties.
+             */
+            const redactedUrl = url.replace(/(access_key|CMC_PRO_API_KEY)=([^&]+)/g, '$1=[REDACTED]');
+            console.error(`Error fetching from ${redactedUrl}: ${error.message}`);
             if (cache.data) return cache.data; // Return stale data on error
             throw error;
         } finally {


### PR DESCRIPTION
### 🚨 Severity: HIGH

### 💡 Vulnerability
External API keys (`metals-api.com` and `CoinMarketCap`) were being leaked in the application's error logs. When a network request failed, the full URL—including sensitive query parameters—was logged to the console via `console.error`.

### 🎯 Impact
If the application logs are accessible to unauthorized users or stored in insecure logging systems, these API keys could be compromised, leading to unauthorized use of paid services or data exposure.

### 🔧 Fix
1.  **URL Redaction:** Added a regular expression in `src/api.js` to replace the values of `access_key` and `CMC_PRO_API_KEY` with `[REDACTED]` before logging the URL.
2.  **Object Sanitization:** Instead of passing the entire `error` object to `console.error`, only the `error.message` is now logged. This prevents potential leakage if the error object contains the original, unredacted request configuration.

### ✅ Verification
- Created a reproduction script that mocks a failed request and checks the console output.
- Verified that the keys are now replaced by `[REDACTED]` and do not appear anywhere in the log.
- Ran the existing test suite (`yarn test` and unit tests) to ensure no regressions.

---
*PR created automatically by Jules for task [4518445033357997848](https://jules.google.com/task/4518445033357997848) started by @VersoriumX*